### PR TITLE
fix require phel version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+ * fix require phel version. Support phel-lang 0.17
+
 ## v0.0.1 (2024-06-25)
 
  * Support phel-lang 0.15

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phel-lang/phel-lang": "^0.15"
+        "phel-lang/phel-lang": ">=0.15 <1.0"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
Changed phel-lang dependency version specification from `“phel-lang/phel-lang”:“^0.15”` to `“phel-lang/phel-lang”:“>=0.15 <1.0”`.

This will support phel-lang 0.17.